### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **DEPRECATION NOTICE**: 
+> * EventStoreDB version 23.10.x is the last OSS version to support the tcp protocol based client.
+> * This project is no longer maintained. 
+
 EventStore Haskell TCP client
 =============================
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 > [!WARNING]
 > **DEPRECATION NOTICE**: 
 > * EventStoreDB version 23.10.x is the last OSS version to support the tcp protocol based client.
-> * This project is no longer maintained. 
 
 EventStore Haskell TCP client
 =============================


### PR DESCRIPTION
@EventStore/devex : similar deprecation notice as the other TCP based clients.


 This repo will be archived after this PR is merged (and #6  ?)